### PR TITLE
1.0.x optional theme manager

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>edu.tamu.weaverframework</groupId>
 		<artifactId>weaver-webservice-parent</artifactId>
-		<version>1.0.2-RC1</version>
+		<version>1.0.2-OptionalThemeManager-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.tamu.weaverframework</groupId>
   <artifactId>weaver-webservice-parent</artifactId>
-  <version>1.0.2-RC1</version>
+  <version>1.0.2-OptionalThemeManager-SNAPSHOT</version>
   <name>weaver-webservice-parent</name>
   <url>http://maven.apache.org</url>
   


### PR DESCRIPTION
There is currently no way to configure whether or not to use the theme manager. This PR adds a new configuration that defaults to false. It also sets defaults to all other theme manager configurations. This will clean up application configuration files that have unused theme manager configurations.
