### PR TITLE
[113][WRO] Start new thread to initialize app theme

### DIFF
--- a/wro/src/main/java/edu/tamu/weaver/wro/service/SimpleThemeManagerService.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/service/SimpleThemeManagerService.java
@@ -57,12 +57,17 @@ public class SimpleThemeManagerService implements ThemeManager {
     @EventListener(ApplicationReadyEvent.class)
     public void initializeResources() {
         if (initializeTheme) {
-            logger.debug("Initializing theme...");
-            try {
-                HttpUtility.makeHttpRequest(cssUrl, "GET");
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            new Thread(new Runnable() {
+                @Override
+                public void run()  {
+                    logger.debug("Initializing theme...");
+                    try {
+                        HttpUtility.makeHttpRequest(cssUrl, "GET");
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }).start();
         }
     }
 }


### PR DESCRIPTION
resolves #113 

Hitting the the theme initialization endpoint from within a new thread seems to be enough to resolve the timing issue in Tomcat. 

Spring-boot deployment is still working as intended.