### PR TITLE
Affiliations need to handle the NULL case otherwise assume user gets NULL rather than UNKNOWN.

### DIFF
--- a/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAssumeUserController.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAssumeUserController.java
@@ -74,7 +74,7 @@ public class WeaverAssumeUserController {
             claims.put("tdl-givenname", info.get("first_name"));
             claims.put("tdl-mail", info.get("tamu_preferred_alias"));
 
-            String affiliation = info.get("employee_type_name");
+            String affiliation = info.getOrDefault("employee_type_name", "");
 
             if ("".equals(affiliation) || "Student".equals(affiliation)) {
                 String classification = info.get("classification_name").split(" ")[0].replace(",", "");

--- a/auth/src/main/java/edu/tamu/weaver/auth/model/Credentials.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/model/Credentials.java
@@ -48,7 +48,7 @@ public class Credentials {
         this.exp = String.valueOf(claims.get("exp"));
         this.email = String.valueOf(claims.get("email"));
         this.role = String.valueOf(claims.get("role"));
-        this.affiliation = String.valueOf(claims.get("affiliation"));
+        this.affiliation = String.valueOf(claims.getOrDefault("affiliation", ""));
         claims.entrySet().forEach(entry -> {
             this.allCredentials.put(entry.getKey(), String.valueOf(entry.getValue()));
         });
@@ -70,7 +70,7 @@ public class Credentials {
         this.exp = String.valueOf(claims.get("exp"));
         this.email = String.valueOf(claims.get("email"));
         this.role = String.valueOf(claims.get("role"));
-        this.affiliation = String.valueOf(claims.get("affiliation"));
+        this.affiliation = String.valueOf(claims.getOrDefault("affiliation", ""));
         claims.entrySet().forEach(entry -> {
             this.allCredentials.put(entry.getKey(), String.valueOf(entry.getValue()));
         });

--- a/auth/src/main/java/edu/tamu/weaver/auth/service/UserCredentialsService.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/service/UserCredentialsService.java
@@ -29,7 +29,7 @@ public abstract class UserCredentialsService<U extends AbstractWeaverUser, R ext
     }
 
     public abstract U updateUserByCredentials(Credentials credentials);
-    
+
     public abstract String getAnonymousRole();
 
 }


### PR DESCRIPTION
The affiliation can be NULL.
The `String.valueOf()` converts NULL to the string "null".
Use instead `getOrDefault()` and provide an empty string.

see: TAMULib/MyLibraryUI#259 and TAMULib/MyLibraryService#182 .