### PR TITLE
Fix issues discovered during attempted upgrade using 2.1.1-RC3.

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.3</version>
     </dependency>
 
     <dependency>

--- a/data/src/main/java/edu/tamu/weaver/data/config/DataConfig.java
+++ b/data/src/main/java/edu/tamu/weaver/data/config/DataConfig.java
@@ -3,11 +3,12 @@ package edu.tamu.weaver.data.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 @Configuration
 public class DataConfig {
@@ -20,19 +21,16 @@ public class DataConfig {
      */
     @Bean
     public ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS, false);
-
-        objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
-        objectMapper.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
-
-        objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
-
-        return objectMapper;
+        return JsonMapper.builder()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+            .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
+            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .build();
     }
 
 }

--- a/data/src/main/java/edu/tamu/weaver/data/service/OrderedEntityService.java
+++ b/data/src/main/java/edu/tamu/weaver/data/service/OrderedEntityService.java
@@ -27,7 +27,7 @@ public class OrderedEntityService {
 
     private static final String POSITION_COLUMN_NAME = "position";
 
-    private static final Long one = new Long(1);
+    private static final Long one = Long.valueOf(1);
 
     @Lazy
     @Autowired

--- a/validation/src/main/java/edu/tamu/weaver/validation/utility/ValidationUtility.java
+++ b/validation/src/main/java/edu/tamu/weaver/validation/utility/ValidationUtility.java
@@ -119,8 +119,8 @@ public class ValidationUtility {
                     } else {
                         invalid = true;
                     }
-                } else if (value instanceof Enum) {
-                    values.add(((Enum) value).name());
+                } else if (value instanceof Enum<?>) {
+                    values.add(((Enum<?>) value).name());
                 } else {
                     values.add((String) value);
                 }

--- a/wro/pom.xml
+++ b/wro/pom.xml
@@ -29,6 +29,12 @@
       <groupId>ro.isdc.wro4j</groupId>
       <artifactId>wro4j-core</artifactId>
       <version>1.10.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -41,6 +47,10 @@
           <artifactId>gmaven-runtime-1.7</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.webjars</groupId>
           <artifactId>webjars-locator-core</artifactId>
         </exclusion>
@@ -51,6 +61,12 @@
       <groupId>org.webjars</groupId>
       <artifactId>webjars-locator-core</artifactId>
       <version>0.50</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
     </dependency>
 
   </dependencies>

--- a/wro/src/main/java/edu/tamu/weaver/wro/config/WeaverWroConfiguration.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/config/WeaverWroConfiguration.java
@@ -44,8 +44,8 @@ public class WeaverWroConfiguration {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
     @Bean
-    public FilterRegistrationBean webResourceOptimizer(Environment env) {
-        FilterRegistrationBean fr = new FilterRegistrationBean();
+    public FilterRegistrationBean<ConfigurableWroFilter> webResourceOptimizer(Environment env) {
+        FilterRegistrationBean<ConfigurableWroFilter> fr = new FilterRegistrationBean<>();
         ConfigurableWroFilter filter = new ConfigurableWroFilter();
         Properties props = buildWroProperties(env);
         filter.setProperties(props);


### PR DESCRIPTION
Remove unnecessary explicit version for postgresql, fixing "Duplicating managed version 42.3.3 for postgresql".

Exclude old conflicting versions of apache commons-io from WRO dependencies, fixing java.lang.NoSuchMethodError: 'java.lang.String org.apache.commons.io.IOUtils.toString(java.io.InputStream, java.nio.charset.Charset).
The latest commons-io is explicitly added.

Add data typs for FilterRegistrationBean, fixing "FilterRegistrationBean is a raw type. References to generic type FilterRegistrationBean<T> should be parameterized"

Add `<?>` to `Enum`, fixing warning.

Replace ObjectMapper instantiation with JsonMapper.builder().
This makes the code cleaner and removes deprecated warnings.

Replace `new Long(1);` with `Long.valueOf(1);`, fixing warning "The constructor Long(long) is deprecated since version 9".