### PR TITLE
Provide a more descriptive error or warning message when the SCSS or CSS file cannot be found.

### DIFF
--- a/wro/src/main/java/edu/tamu/weaver/wro/resource/locator/SassClassPathUriLocator.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/resource/locator/SassClassPathUriLocator.java
@@ -121,6 +121,7 @@ public class SassClassPathUriLocator implements UriLocator {
      * The exists() check should not throw an exception when the resource does not exist.
      *
      * The stack trace is suppressed unless debug is enabled.
+     * When debug is disabled, a warning message is instead printed.
      *
      * @param resource The resource to check.
      * @param uri The URI represented by the resource (used for error logging).
@@ -130,7 +131,7 @@ public class SassClassPathUriLocator implements UriLocator {
         try {
             return resource.exists();
         } catch (IllegalArgumentException e) {
-            String message = "Existence check failed for URI: " + uri;
+            String message = "Failed to find SCSS or CSS file for the URI: " + uri;
             if (LOG.isDebugEnabled()) {
                 LOG.error(message, e);
             } else {


### PR DESCRIPTION
This should help make the error message more user-friendly for users who do not know the details of how Weaver or WRO is designed.
Such a user need only know that a particular SCSS or CSS file could not be located.

Feel free to suggest alternative descriptions of the error or warning message.