### PR TITLE
Properly utilize cssGroupName config property

### DIFF
--- a/wro/src/main/java/edu/tamu/weaver/wro/config/WeaverWroConfiguration.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/config/WeaverWroConfiguration.java
@@ -59,26 +59,26 @@ public class WeaverWroConfiguration {
 
     @Bean
     public ThemeManager setThemeManagerServiceBean() {
-      logger.debug("Creating ThemeManagerService Bean with configured class: "+themeManagerServiceClassName);
-      Class<?> clazz;
-      try {
-        clazz = Class.forName(themeManagerServiceClassName);
-        Constructor<?> constructor;
+        logger.debug("Creating ThemeManagerService Bean with configured class: "+themeManagerServiceClassName);
+        Class<?> clazz;
         try {
-          constructor = clazz.getConstructor();
-          return (ThemeManager) constructor.newInstance();
-        } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-          e.printStackTrace();
-          logger.error("Could not create ThemeManagerService Bean with class: "+themeManagerServiceClassName, e);
-        }
+            clazz = Class.forName(themeManagerServiceClassName);
+            Constructor<?> constructor;
+            try {
+                constructor = clazz.getConstructor();
+                return (ThemeManager) constructor.newInstance();
+            } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                e.printStackTrace();
+                logger.error("Could not create ThemeManagerService Bean with class: "+themeManagerServiceClassName, e);
+            }
         } catch (ClassNotFoundException e) {
             logger.warn("Could not find ThemeManagerService implementation class: " + themeManagerServiceClassName + "! Application must create theme manager bean!");
         }
-      return null;
+        return null;
     }
 
     protected Properties buildWroProperties(Environment env) {
-      Properties props = buildDefaultWroProperties(env);
+        Properties props = buildDefaultWroProperties(env);
         return props;
     }
 
@@ -103,17 +103,17 @@ public class WeaverWroConfiguration {
     @Autowired
     @Lazy
     public void setThemeManagerService(ThemeManager themeManagerService) {
-      this.themeManagerService = themeManagerService;
+        this.themeManagerService = themeManagerService;
     }
 
     public ThemeManager getThemeManagerService() {
-      return themeManagerService;
+        return themeManagerService;
     }
 
     @Lazy
     @Autowired
     protected void setResourcePatternResolver(ResourcePatternResolver resourcePatternResolver) {
-      this.resourcePatternResolver = resourcePatternResolver;
+        this.resourcePatternResolver = resourcePatternResolver;
     }
 
     public ResourcePatternResolver getResourcePatternResolver() {
@@ -121,26 +121,30 @@ public class WeaverWroConfiguration {
     }
 
     protected void setPropertyPrefix(String propertyPrefix) {
-      this.propertyPrefix = propertyPrefix;
+        this.propertyPrefix = propertyPrefix;
     }
 
     protected String getPropertyPrefix() {
-      return propertyPrefix;
+        return propertyPrefix;
     }
 
     protected void setWroEndpoint(String wroEndpoint) {
-      this.wroEndpoint = wroEndpoint;
+        this.wroEndpoint = wroEndpoint;
     }
 
     protected String getWroEndpoint() {
-      return wroEndpoint;
+        return wroEndpoint;
+    }
+
+    protected String getCssGroupName() {
+        return cssGroupName;
     }
 
     protected WroManagerFactory getWroManagerFactory(Properties properties) {
-      return new WeaverConfigurableWroManagerFactory(properties, getThemeManagerService(), resourcePatternResolver);
+        return new WeaverConfigurableWroManagerFactory(properties, getThemeManagerService(), resourcePatternResolver, getCssGroupName());
     }
 
     protected RequestHandler getRequestHandler() {
-      return new WeaverRequestHandler();
+        return new WeaverRequestHandler();
     }
 }

--- a/wro/src/main/java/edu/tamu/weaver/wro/manager/factory/WeaverConfigurableWroManagerFactory.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/manager/factory/WeaverConfigurableWroManagerFactory.java
@@ -23,12 +23,21 @@ public class WeaverConfigurableWroManagerFactory extends ConfigurableWroManagerF
 	private ThemeManager themeManagerService;
 
 	private Properties properties;
+
+	private String cssGroupName;
 	
 	private ResourcePatternResolver resourcePatternResolver;
 
+	private static final String DEFAULT_CSS_GROUP_NAME = "app";
+
 	public WeaverConfigurableWroManagerFactory(Properties props, ThemeManager themeManagerService, ResourcePatternResolver resourcePatternResolver) {
+		this(props, themeManagerService, resourcePatternResolver, DEFAULT_CSS_GROUP_NAME);
+	}
+
+	public WeaverConfigurableWroManagerFactory(Properties props, ThemeManager themeManagerService, ResourcePatternResolver resourcePatternResolver, String cssGroupName) {
 		setProperties(props);
 		setThemeManagerService(themeManagerService);
+		setCssGroupName(cssGroupName);
 		this.resourcePatternResolver = resourcePatternResolver;
 	}
 
@@ -44,7 +53,7 @@ public class WeaverConfigurableWroManagerFactory extends ConfigurableWroManagerF
 
 	@Override
 	protected WroModelFactory newModelFactory() {
-		return new WeaverWroModelFactory(getThemeManagerService().getCssResources(),"app");
+		return new WeaverWroModelFactory(getThemeManagerService().getCssResources(), getCssGroupName());
 	}
 	
 	protected void setProperties(Properties properties) {
@@ -61,6 +70,14 @@ public class WeaverConfigurableWroManagerFactory extends ConfigurableWroManagerF
 
 	protected ThemeManager getThemeManagerService() {
 		return themeManagerService;
+	}
+
+    protected void setCssGroupName(String cssGroupName) {
+		this.cssGroupName = cssGroupName;
+	}
+
+    protected String getCssGroupName() {
+		return cssGroupName;
 	}
 	
 	protected UriLocatorFactory newUriLocatorFactory() {

--- a/wro/src/main/java/edu/tamu/weaver/wro/service/SimpleThemeManagerService.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/service/SimpleThemeManagerService.java
@@ -50,6 +50,14 @@ public class SimpleThemeManagerService implements ThemeManager {
         return null;
     }
 
+    protected void setCssUrl(String cssUrl) {
+        this.cssUrl = cssUrl;
+    }
+
+    protected String getCssUrl() {
+        return this.cssUrl;
+    }
+
     /**
      * Build the CSS as soon as the the app is running
      *
@@ -64,6 +72,7 @@ public class SimpleThemeManagerService implements ThemeManager {
                     try {
                         HttpUtility.makeHttpRequest(cssUrl, "GET");
                     } catch (IOException e) {
+                        logger.warn("Failed to initialize theme for URL: "+getCssUrl());
                         e.printStackTrace();
                     }
                 }


### PR DESCRIPTION
This is a bug fix for Weaver WRO not utilizing the optional `theme.cssGroupName` configuration property when set.

No current clients are actually utilizing this property.

The three argument constructor in [WeaverConfigurableWroManagerFactory.java](https://github.com/TAMULib/Weaver-Webservice-Core/compare/wro-fix?expand=1#diff-147dc0158dcc47e30e2b8beb192458ee850158a65d2c6d7be343601ae15e535f) is preserved here to for backward compatibility with Vireo's custom WRO configuration.