### PR TITLE
Internal Sprint 10: Upgrade to Spring Boot 2.7.18.

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.tamu.weaver</groupId>
   <artifactId>webservice-parent</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.1-RC1</version>
 
   <name>Weaver Webservice Parent</name>
 
@@ -36,7 +36,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot.version>2.6.14</spring.boot.version>
+    <spring.boot.version>2.7.18</spring.boot.version>
     <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
   </properties>
 

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/token-provider/pom.xml
+++ b/token-provider/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/token/pom.xml
+++ b/token/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/wro/pom.xml
+++ b/wro/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-RC1</version>
   </parent>
 
   <dependencies>

--- a/wro/src/main/java/edu/tamu/weaver/wro/model/repo/impl/CoreThemeRepoImpl.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/model/repo/impl/CoreThemeRepoImpl.java
@@ -86,7 +86,7 @@ public class CoreThemeRepoImpl extends AbstractWeaverRepoImpl<CoreTheme, CoreThe
 
             themePropertyRepo.update(themeProperty);
 
-            ThemePropertyName themePropertyName = themePropertyNameRepo.getById(themePropertyId);
+            ThemePropertyName themePropertyName = themePropertyNameRepo.getReferenceById(themePropertyId);
             if (themePropertyRepo.findThemePropertyByThemePropertyName(themePropertyName).isEmpty()) {
                 themPropertyNamesToDelete.add(themePropertyName);
             }


### PR DESCRIPTION
# Description

Update Spring Boot version from 2.6.14 to 2.7.18.
Changed weaver version as 2.2.1-RC1.
Additionally resolved a minor deprecation with a `getById` call being changed to `getReferenceById`.

Deprecation listing with `WebSecurityConfigurerAdapter` is intended to be resolved in the conversion from Spring Boot 2.7.18 to Spring Boot 3.0.13.

Resolves #169.

This upgrade is expected to be deployed as its own version (2.2.1), so reviewers should confirm the release cut version formatting before accepting.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested using Local TAMULib Directory with `mvn clean test`
- [x] Verified using Local TAMULib Directory with `mvn clean spring-boot:run`

New Weaver version `2.2.1-RC1` was referenced within the Directory project using a deploy to a local maven repository.

**Test Configuration**:
* Toolchain: WSL (Devuan Linux), Java 21, Maven 3.9.9.
* SDK:
```
openjdk 21.0.11 2026-04-21
OpenJDK Runtime Environment (build 21.0.11+10-1-deb13u2-Debian)
OpenJDK 64-Bit Server VM (build 21.0.11+10-1-deb13u2-Debian, mixed mode, sharing)
```
```
Apache Maven 3.9.9
Maven home: /usr/share/maven
Java version: 21.0.11, vendor: Debian, runtime: /usr/lib/jvm/java-21-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.18.33.1-microsoft-standard-wsl2", arch: "amd64", family: "unix"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
