### PR TITLE
Internal Sprint 10: Upgrade to Spring Boot 3.0.13.

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/auth/src/main/java/edu/tamu/weaver/auth/config/AuthWebSecurityConfig.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/config/AuthWebSecurityConfig.java
@@ -5,13 +5,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.FilterInvocation;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 
 import edu.tamu.weaver.auth.filter.TokenAuthorizationFilter;
@@ -19,7 +21,7 @@ import edu.tamu.weaver.auth.model.AbstractWeaverUserDetails;
 import edu.tamu.weaver.auth.model.repo.AbstractWeaverUserRepo;
 import edu.tamu.weaver.auth.service.AbstractWeaverUserDetailsService;
 
-public abstract class AuthWebSecurityConfig<U extends AbstractWeaverUserDetails, R extends AbstractWeaverUserRepo<U>, S extends AbstractWeaverUserDetailsService<U, R>> extends WebSecurityConfigurerAdapter {
+public abstract class AuthWebSecurityConfig<U extends AbstractWeaverUserDetails, R extends AbstractWeaverUserRepo<U>, S extends AbstractWeaverUserDetailsService<U, R>> {
 
     @Autowired
     private S userDetailsService;
@@ -30,6 +32,11 @@ public abstract class AuthWebSecurityConfig<U extends AbstractWeaverUserDetails,
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
         auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
@@ -45,8 +52,8 @@ public abstract class AuthWebSecurityConfig<U extends AbstractWeaverUserDetails,
     }
 
     @Bean
-    public TokenAuthorizationFilter<U, R, S> tokenAuthorizationFilter() throws Exception {
-        return new TokenAuthorizationFilter<U, R, S>(authenticationManager());
+    public TokenAuthorizationFilter<U, R, S> tokenAuthorizationFilter(AuthenticationManager authenticationManager) throws Exception {
+        return new TokenAuthorizationFilter<U, R, S>(authenticationManager);
     }
 
     protected SecurityExpressionHandler<FilterInvocation> webExpressionHandler() {
@@ -55,8 +62,7 @@ public abstract class AuthWebSecurityConfig<U extends AbstractWeaverUserDetails,
         return defaultWebSecurityExpressionHandler;
     }
 
-    @Override
-    protected abstract void configure(HttpSecurity http) throws Exception;
+    public abstract SecurityFilterChain configure(HttpSecurity http) throws Exception;
 
     protected abstract String buildRoleHierarchy();
 

--- a/auth/src/main/java/edu/tamu/weaver/auth/filter/TokenAuthorizationFilter.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/filter/TokenAuthorizationFilter.java
@@ -10,10 +10,10 @@ import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/auth/src/main/java/edu/tamu/weaver/auth/proxy/FilterSecurityInterceptorProxy.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/proxy/FilterSecurityInterceptorProxy.java
@@ -1,6 +1,6 @@
 package edu.tamu.weaver.auth.proxy;
 
-import javax.servlet.Filter;
+import jakarta.servlet.Filter;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;

--- a/auth/src/main/java/edu/tamu/weaver/auth/proxy/RequestMappingHandlerProxy.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/proxy/RequestMappingHandlerProxy.java
@@ -3,7 +3,7 @@ package edu.tamu.weaver.auth.proxy;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/auth/src/main/java/edu/tamu/weaver/auth/service/RestAccessManagerService.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/service/RestAccessManagerService.java
@@ -5,7 +5,7 @@ import static edu.tamu.weaver.auth.model.AccessDecision.REQUIRES_AUTHENTICATION;
 import java.util.Collection;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.web.FilterInvocation;

--- a/auth/src/main/java/edu/tamu/weaver/auth/whitelist/Whitelist.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/whitelist/Whitelist.java
@@ -7,7 +7,7 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/data/src/main/java/edu/tamu/weaver/data/model/BaseEntity.java
+++ b/data/src/main/java/edu/tamu/weaver/data/model/BaseEntity.java
@@ -1,12 +1,12 @@
 package edu.tamu.weaver.data.model;
 
-import static javax.persistence.GenerationType.IDENTITY;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 import java.util.Objects;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 import com.fasterxml.jackson.annotation.JsonView;
 

--- a/data/src/main/java/edu/tamu/weaver/data/model/OrderedBaseEntity.java
+++ b/data/src/main/java/edu/tamu/weaver/data/model/OrderedBaseEntity.java
@@ -9,8 +9,8 @@
  */
 package edu.tamu.weaver.data.model;
 
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public abstract class OrderedBaseEntity extends BaseEntity implements WeaverOrderedEntity {

--- a/data/src/main/java/edu/tamu/weaver/data/model/repo/impl/AbstractWeaverRepoImpl.java
+++ b/data/src/main/java/edu/tamu/weaver/data/model/repo/impl/AbstractWeaverRepoImpl.java
@@ -10,7 +10,7 @@ import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 import java.util.List;
 import java.util.Optional;
 
-import javax.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;

--- a/data/src/main/java/edu/tamu/weaver/data/resolver/BaseEntityIdResolver.java
+++ b/data/src/main/java/edu/tamu/weaver/data/resolver/BaseEntityIdResolver.java
@@ -1,7 +1,7 @@
 package edu.tamu.weaver.data.resolver;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;

--- a/data/src/main/java/edu/tamu/weaver/data/resolver/EntityByPropertyResolver.java
+++ b/data/src/main/java/edu/tamu/weaver/data/resolver/EntityByPropertyResolver.java
@@ -1,10 +1,10 @@
 package edu.tamu.weaver.data.resolver;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;

--- a/data/src/main/java/edu/tamu/weaver/data/service/OrderedEntityService.java
+++ b/data/src/main/java/edu/tamu/weaver/data/service/OrderedEntityService.java
@@ -3,13 +3,13 @@ package edu.tamu.weaver.data.service;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/data/src/main/java/edu/tamu/weaver/data/utility/EntityUtility.java
+++ b/data/src/main/java/edu/tamu/weaver/data/utility/EntityUtility.java
@@ -6,18 +6,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.EntityManager;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
 
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
-
-import org.hibernate.query.criteria.internal.path.PluralAttributePath;
 
 import edu.tamu.weaver.context.SpringContext;
 
@@ -191,7 +190,8 @@ public class EntityUtility {
         Path<Object> path = null;
         for (String p : property.split("\\.")) {
             if (path == null) {
-                if (root.get(p) instanceof PluralAttributePath) {
+                Attribute<?,?> attr = root.getModel().getAttribute(p);
+                if (attr.isCollection()) {
                     path = root.join(p);
                 } else {
                     path = root.get(p);

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/email/src/main/java/edu/tamu/weaver/email/service/EmailSender.java
+++ b/email/src/main/java/edu/tamu/weaver/email/service/EmailSender.java
@@ -1,6 +1,6 @@
 package edu.tamu.weaver.email.service;
 
-import javax.mail.MessagingException;
+import jakarta.mail.MessagingException;
 
 import org.springframework.mail.javamail.JavaMailSender;
 

--- a/email/src/main/java/edu/tamu/weaver/email/service/MockEmailService.java
+++ b/email/src/main/java/edu/tamu/weaver/email/service/MockEmailService.java
@@ -1,6 +1,6 @@
 package edu.tamu.weaver.email.service;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 
 import org.springframework.mail.MailException;
 

--- a/email/src/main/java/edu/tamu/weaver/email/service/WeaverEmailService.java
+++ b/email/src/main/java/edu/tamu/weaver/email/service/WeaverEmailService.java
@@ -2,8 +2,8 @@ package edu.tamu.weaver.email.service;
 
 import java.util.Properties;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>
@@ -20,6 +20,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-activemq</artifactId>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.tamu.weaver</groupId>
   <artifactId>webservice-parent</artifactId>
-  <version>2.2.1-RC1</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <name>Weaver Webservice Parent</name>
 
@@ -32,11 +32,11 @@
   <packaging>pom</packaging>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>21</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot.version>2.7.18</spring.boot.version>
+    <spring.boot.version>3.0.13</spring.boot.version>
     <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
   </properties>
 
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>2021.0.6</version>
+        <version>2022.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -86,7 +86,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
           <configuration>
             <delimiters>
               <delimiter>@</delimiter>
@@ -97,7 +97,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.8</version>
+          <version>0.8.15</version>
           <executions>
             <execution>
               <id>default-prepare-agent</id>
@@ -136,7 +136,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.0</version>
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.boot.version>3.0.13</spring.boot.version>
     <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
+    <cloud-dependencies.version>2022.0.5</cloud-dependencies.version>
+    <maven.plugins.version>3.5.0</maven.plugins.version>
+    <jacoco.plugin.version>0.8.15</jacoco.plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -52,7 +55,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>2022.0.5</version>
+        <version>${cloud-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -86,7 +89,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>${maven.plugins.version}</version>
           <configuration>
             <delimiters>
               <delimiter>@</delimiter>
@@ -97,7 +100,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.15</version>
+          <version>${jacoco.plugin.version}</version>
           <executions>
             <execution>
               <id>default-prepare-agent</id>
@@ -136,7 +139,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>${maven.plugins.version}</version>
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/token-provider/pom.xml
+++ b/token-provider/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
@@ -11,7 +11,6 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
-import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.token.service.TokenService;
@@ -42,8 +43,8 @@ public class TokenController {
             throw new RuntimeException("No referrer in params!!");
         }
         LOG.debug("headers: " + headers);
-        URIBuilder builder = new URIBuilder(referrer.replace(" ", "%20"));
-        builder.addParameter("jwt", tokenService.craftToken(headers));
+        UriBuilder builder = UriComponentsBuilder.fromUriString(referrer.replace(" ", "%20"));
+        builder.queryParam("jwt", tokenService.craftToken(headers));
         String url = builder.build().toASCIIString();
         LOG.debug(String.format("Auth url redirect: %s", url));
         RedirectView redirect = new RedirectView();

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
@@ -1,6 +1,7 @@
 package edu.tamu.weaver.token.provider.controller;
 
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
+import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.UriBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.token.service.TokenService;
@@ -43,7 +43,7 @@ public class TokenController {
             throw new RuntimeException("No referrer in params!!");
         }
         LOG.debug("headers: " + headers);
-        UriBuilder builder = UriComponentsBuilder.fromUriString(referrer.replace(" ", "%20"));
+        UriBuilder builder = fromUriString(referrer.replace(" ", "%20"));
         builder.queryParam("jwt", tokenService.craftToken(headers));
         String url = builder.build().toASCIIString();
         LOG.debug(String.format("Auth url redirect: %s", url));

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
@@ -1,6 +1,7 @@
 package edu.tamu.weaver.token.provider.controller;
 
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
+import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.UriBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import edu.tamu.weaver.response.ApiResponse;
 
@@ -64,7 +64,7 @@ public abstract class WeaverMockTokenController extends TokenController {
         if (mock == null) {
             mock = "user";
         }
-        UriBuilder builder = UriComponentsBuilder.fromUriString(referrer);
+        UriBuilder builder = fromUriString(referrer);
         builder.queryParam("jwt", tokenService.craftToken(MOCK_CLAIMS.get(mock)));
         String url = builder.build().toASCIIString();
         LOG.debug(String.format("Auth url redirect: %s", url));

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
@@ -12,13 +12,14 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
-import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import edu.tamu.weaver.response.ApiResponse;
 
@@ -63,8 +64,8 @@ public abstract class WeaverMockTokenController extends TokenController {
         if (mock == null) {
             mock = "user";
         }
-        URIBuilder builder = new URIBuilder(referrer);
-        builder.addParameter("jwt", tokenService.craftToken(MOCK_CLAIMS.get(mock)));
+        UriBuilder builder = UriComponentsBuilder.fromUriString(referrer);
+        builder.queryParam("jwt", tokenService.craftToken(MOCK_CLAIMS.get(mock)));
         String url = builder.build().toASCIIString();
         LOG.debug(String.format("Auth url redirect: %s", url));
         RedirectView redirect = new RedirectView();

--- a/token/pom.xml
+++ b/token/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/token/src/main/java/edu/tamu/weaver/token/service/TokenService.java
+++ b/token/src/main/java/edu/tamu/weaver/token/service/TokenService.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/user/src/main/java/edu/tamu/weaver/user/model/AbstractWeaverUser.java
+++ b/user/src/main/java/edu/tamu/weaver/user/model/AbstractWeaverUser.java
@@ -1,8 +1,8 @@
 package edu.tamu.weaver.user.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/validation/src/main/java/edu/tamu/weaver/validation/model/ValidatingBaseEntity.java
+++ b/validation/src/main/java/edu/tamu/weaver/validation/model/ValidatingBaseEntity.java
@@ -1,7 +1,7 @@
 package edu.tamu.weaver.validation.model;
 
-import javax.persistence.MappedSuperclass;
-import javax.persistence.Transient;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/validation/src/main/java/edu/tamu/weaver/validation/model/ValidatingOrderedBaseEntity.java
+++ b/validation/src/main/java/edu/tamu/weaver/validation/model/ValidatingOrderedBaseEntity.java
@@ -1,7 +1,7 @@
 package edu.tamu.weaver.validation.model;
 
-import javax.persistence.MappedSuperclass;
-import javax.persistence.Transient;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/validation/src/main/java/edu/tamu/weaver/validation/utility/ValidationUtility.java
+++ b/validation/src/main/java/edu/tamu/weaver/validation/utility/ValidationUtility.java
@@ -22,11 +22,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 
 import edu.tamu.weaver.context.SpringContext;
 import edu.tamu.weaver.data.model.WeaverEntity;

--- a/wro/pom.xml
+++ b/wro/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <wro4j.version>2.1.1</wro4j.version>
+    <webjars.version>0.52</webjars.version>
+    <commons-io.version>2.11.0</commons-io.version>
   </properties>
 
   <dependencies>
@@ -68,13 +70,13 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>webjars-locator-core</artifactId>
-      <version>0.59</version>
+      <version>${webjars.version}</version>
     </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.18.0</version>
+      <version>${commons-io.version}</version>
     </dependency>
 
   </dependencies>

--- a/wro/pom.xml
+++ b/wro/pom.xml
@@ -13,8 +13,12 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.2.1-RC1</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
+
+  <properties>
+    <wro4j.version>2.1.1</wro4j.version>
+  </properties>
 
   <dependencies>
 
@@ -28,7 +32,7 @@
     <dependency>
       <groupId>ro.isdc.wro4j</groupId>
       <artifactId>wro4j-core</artifactId>
-      <version>1.10.1</version>
+      <version>${wro4j.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>
@@ -40,7 +44,7 @@
     <dependency>
       <groupId>ro.isdc.wro4j</groupId>
       <artifactId>wro4j-extensions</artifactId>
-      <version>1.10.1</version>
+      <version>${wro4j.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.gmaven.runtime</groupId>
@@ -64,13 +68,13 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>webjars-locator-core</artifactId>
-      <version>0.52</version>
+      <version>0.59</version>
     </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.18.0</version>
     </dependency>
 
   </dependencies>

--- a/wro/src/main/java/edu/tamu/weaver/wro/model/CoreTheme.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/model/CoreTheme.java
@@ -1,17 +1,17 @@
 package edu.tamu.weaver.wro.model;
 
-import static javax.persistence.CascadeType.DETACH;
-import static javax.persistence.CascadeType.MERGE;
-import static javax.persistence.CascadeType.REFRESH;
-import static javax.persistence.FetchType.EAGER;
+import static jakarta.persistence.CascadeType.DETACH;
+import static jakarta.persistence.CascadeType.MERGE;
+import static jakarta.persistence.CascadeType.REFRESH;
+import static jakarta.persistence.FetchType.EAGER;
 import static org.hibernate.annotations.FetchMode.SELECT;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 
 import org.hibernate.annotations.Fetch;
 

--- a/wro/src/main/java/edu/tamu/weaver/wro/model/ThemeProperty.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/model/ThemeProperty.java
@@ -1,10 +1,10 @@
 package edu.tamu.weaver.wro.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;

--- a/wro/src/main/java/edu/tamu/weaver/wro/model/ThemePropertyName.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/model/ThemePropertyName.java
@@ -1,7 +1,7 @@
 package edu.tamu.weaver.wro.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 
 import edu.tamu.weaver.data.model.BaseEntity;
 

--- a/wro/src/main/java/edu/tamu/weaver/wro/model/repo/impl/CoreThemeRepoImpl.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/model/repo/impl/CoreThemeRepoImpl.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;

--- a/wro/src/main/java/edu/tamu/weaver/wro/service/RepoThemeManagerService.java
+++ b/wro/src/main/java/edu/tamu/weaver/wro/service/RepoThemeManagerService.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/wro/src/main/java/wro4j/http/handler/WeaverRequestHandler.java
+++ b/wro/src/main/java/wro4j/http/handler/WeaverRequestHandler.java
@@ -2,8 +2,8 @@ package wro4j.http.handler;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
# Description

Update Spring Boot version from 2.7.18 to 3.0.13.
Changed weaver version as 2.3.0-SNAPSHOT.

Migrated security to Spring-security 6.0.8:
- Switched from extending `WebSecurityConfigurerAdapter` to provding an abstract `SecurityFilterChain` function.
- Created a public `AuthenticationManager` bean to be used as an argument where appropriate.

Migrated all applicable `javax` libraries to `jakarta`.
`wro4j` libraries are updated to a newer version, defined by a new property within `wro/pom.xml`.

Additionally handled some deprecated libraries:
- `org.hibernate...PluralAttributePath` functionality is replaced with use of `jakarta.persistence.metamodel.Attribute` and the `.isCollection()` method.
- `org.apache.http.client.utils.URIBuilder` is replaced with `org.springframework.web.util.UriBuilder` and `org.springframework.web.util.UriComponentsBuilder`.

Resolves #168 and #170.

This upgrade is expected to be deployed as its own version (2.3.0), so reviewers should confirm the _snapshot_ version formatting before accepting.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested using Local TAMULib Directory with `mvn clean test`
- [x] Verified using Local TAMULib Directory with `mvn clean spring-boot:run`

New Weaver version `2.3.0-SNAPSHOT` was referenced within the Directory project using a deploy to a local maven repository.

**Test Configuration**:
* Toolchain: WSL (Devuan Linux), Java 21, Maven 3.9.9.
* SDK:
```
openjdk 21.0.11 2026-04-21
OpenJDK Runtime Environment (build 21.0.11+10-1-deb13u2-Debian)
OpenJDK 64-Bit Server VM (build 21.0.11+10-1-deb13u2-Debian, mixed mode, sharing)
```
```
Apache Maven 3.9.9
Maven home: /usr/share/maven
Java version: 21.0.11, vendor: Debian, runtime: /usr/lib/jvm/java-21-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.18.33.1-microsoft-standard-wsl2", arch: "amd64", family: "unix"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

