### PR TITLE
Internal Sprint 10: Upgrade to Spring Boot 3.2.12.

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAssumeUserController.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAssumeUserController.java
@@ -51,7 +51,7 @@ public class WeaverAssumeUserController {
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     @RequestMapping(method = RequestMethod.GET)
-    public ApiResponse assume(@RequestParam() Map<String, String> params) throws Exception {
+    public ApiResponse assume(@RequestParam("params") Map<String, String> params) throws Exception {
 
         ApiResponse apiResponse;
 

--- a/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAuthController.java
+++ b/auth/src/main/java/edu/tamu/weaver/auth/controller/WeaverAuthController.java
@@ -33,7 +33,7 @@ public abstract class WeaverAuthController {
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public abstract ApiResponse registration(@RequestBody Map<String, String> dataMap, @RequestParam Map<String, String> parameters);
+    public abstract ApiResponse registration(@RequestBody Map<String, String> dataMap, @RequestParam("parameters") Map<String, String> parameters);
 
     public abstract ApiResponse login(@RequestBody Map<String, String> dataMap);
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,15 +13,19 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
+
+  <properties>
+    <jakarta.servlet.version>6.2.0-M2</jakarta.servlet.version>
+  </properties>
 
   <dependencies>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>3.0-alpha-1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.tamu.weaver</groupId>
   <artifactId>webservice-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Weaver Webservice Parent</name>
 
@@ -36,7 +36,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot.version>3.1.12</spring.boot.version>
+    <spring.boot.version>3.2.12</spring.boot.version>
     <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
     <cloud-dependencies.version>2022.0.5</cloud-dependencies.version>
     <maven.plugins.version>3.5.0</maven.plugins.version>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/token-provider/pom.xml
+++ b/token-provider/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/TokenController.java
@@ -35,7 +35,7 @@ public class TokenController {
     protected TokenService tokenService;
 
     @RequestMapping("/token")
-    public RedirectView token(@RequestParam Map<String, String> params, @RequestHeader Map<String, String> headers) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException, URISyntaxException {
+    public RedirectView token(@RequestParam("params") Map<String, String> params, @RequestHeader Map<String, String> headers) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException, URISyntaxException {
         LOG.debug("params: " + params);
         String referrer = params.get("referrer");
         if (referrer == null) {
@@ -54,7 +54,7 @@ public class TokenController {
     }
 
     @RequestMapping("/refresh")
-    public ApiResponse refresh(@RequestParam(required = true) String token) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException {
+    public ApiResponse refresh(@RequestParam(name = "token", required = true) String token) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException {
         LOG.debug("Refresh token requested.");
         return new ApiResponse(SUCCESS, "Token refresh successful.", tokenService.refreshToken(token));
     }

--- a/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
+++ b/token-provider/src/main/java/edu/tamu/weaver/token/provider/controller/WeaverMockTokenController.java
@@ -53,7 +53,7 @@ public abstract class WeaverMockTokenController extends TokenController {
 
     @Override
     @RequestMapping("/token")
-    public RedirectView token(@RequestParam Map<String, String> params, @RequestHeader Map<String, String> headers) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException, URISyntaxException {
+    public RedirectView token(@RequestParam("params") Map<String, String> params, @RequestHeader Map<String, String> headers) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException, URISyntaxException {
         LOG.debug("params: " + params);
         String referrer = params.get("referrer");
         if (referrer == null) {
@@ -76,7 +76,7 @@ public abstract class WeaverMockTokenController extends TokenController {
 
     @Override
     @RequestMapping("/refresh")
-    public ApiResponse refresh(@RequestParam(required = true) String token) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException {
+    public ApiResponse refresh(@RequestParam(name = "token", required = true) String token) throws InvalidKeyException, NoSuchAlgorithmException, NoSuchPaddingException, IllegalBlockSizeException, BadPaddingException {
         LOG.debug("Refresh token requested.");
         return new ApiResponse(SUCCESS, "Token refresh successful.", tokenService.refreshToken(token));
     }

--- a/token/pom.xml
+++ b/token/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/user/pom.xml
+++ b/user/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/validation/src/main/java/edu/tamu/weaver/validation/controller/ValidationsController.java
+++ b/validation/src/main/java/edu/tamu/weaver/validation/controller/ValidationsController.java
@@ -36,7 +36,7 @@ public class ValidationsController {
     private String[] modelPackages;
 
     @RequestMapping("/{entityName}")
-    public ApiResponse validations(@PathVariable String entityName) {
+    public ApiResponse validations(@PathVariable("entityName") String entityName) {
 
         ApiResponse response = new ApiResponse(INVALID);
 

--- a/wro/pom.xml
+++ b/wro/pom.xml
@@ -13,13 +13,13 @@
   <parent>
     <groupId>edu.tamu.weaver</groupId>
     <artifactId>webservice-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <properties>
     <wro4j.version>2.1.1</wro4j.version>
-    <webjars.version>0.52</webjars.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <webjars.version>0.59</webjars.version>
+    <commons-io.version>2.18.0</commons-io.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# Description

Update Spring Boot version from 3.1.12 to 3.2.12.
Changed Weaver version as 2.3.2-SNAPSHOT.

Additional changes:
* Added value names to `@RequestParam` and `@PathVariable` parameters. This is due to 3.2.12 bringing in Spring Framework 6.1, which removes compatibility with reflection name discovery.
* Updated dependency versions to be compatable with the parameter compatibility change, including switching `javax.servlet` `servlet-api` with `jakarta.servlet` `jakarta.servlet-api`.

Projects migrating from 3.1.12 to 3.2.12 using Weaver are expected to follow similar changes to `@RequestParam`, `@PathVariable`, and any additional affected dependencies. Alternatively, add the plugin details as seen in the provided source.

**Source**: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.1-Release-Notes

Resolves #176.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested using Local TAMULib Directory with `mvn clean test`
- [x] Verified using Local TAMULib Directory with `mvn clean spring-boot:run`

New Weaver version `2.3.2-SNAPSHOT` was referenced within the Directory project using a deploy to a local maven repository.

**Test Configuration**:
* Toolchain: WSL (Devuan Linux), Java 21, Maven 3.9.9.
* SDK:
```
openjdk 21.0.11 2026-04-21
OpenJDK Runtime Environment (build 21.0.11+10-1-deb13u2-Debian)
OpenJDK 64-Bit Server VM (build 21.0.11+10-1-deb13u2-Debian, mixed mode, sharing)
```
```
Apache Maven 3.9.9
Maven home: /usr/share/maven
Java version: 21.0.11, vendor: Debian, runtime: /usr/lib/jvm/java-21-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.18.33.1-microsoft-standard-wsl2", arch: "amd64", family: "unix"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

